### PR TITLE
Added cost of MonoPropellant to part cost to fix negative cost.

### DIFF
--- a/Output/GameData/NRAP/Parts/Test/part.cfg
+++ b/Output/GameData/NRAP/Parts/Test/part.cfg
@@ -13,7 +13,7 @@ PART
 
 	TechRequired = start
 	entryCost = 2500
-	cost = 250
+	cost = 1450 // 250 dry + cost of 1000 MonoPropellant @ KSP 1.0.2 rate
 	category = Utility
 	subcategory = 0
 	title = NRAP - Test weight


### PR DESCRIPTION
Set the base cost of the NRAP weight to 1450 so the cost with no MonoPropellant will be 250 instead of negative.
